### PR TITLE
Feature/v1.0.0/comments column rename

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,7 +27,7 @@ class CommentsController < ApplicationController
   private
 
     def comment_params
-      # formから渡ってきたパラメーターのうちcomment_textだけを許容する
-      params.require(:comment).permit(:comment_text)
+      # formから渡ってきたパラメーターのうちtextだけを許容する
+      params.require(:comment).permit(:text)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -27,7 +27,7 @@ class MessagesController < ApplicationController
   private
 
     def message_params
-      # formから渡ってきたパラメーターのうちmessage_textだけを許容する
-      params.require(:message).permit(:message_text)
+      # formから渡ってきたパラメーターのうちtextだけを許容する
+      params.require(:message).permit(:text)
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
-  validates :comment_text, {presence: true, length: {maximum: 1000}}
+  validates :text, {presence: true, length: {maximum: 1000}}
 
   belongs_to :user
   belongs_to :post

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  validates :message_text, {presence: true, length: {maximum: 1000}}
+  validates :text, {presence: true, length: {maximum: 1000}}
 
   belongs_to :room
   belongs_to :user

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -54,7 +54,7 @@
           </div>
         </div>
         <div class="overflow-wrap">
-          <%= c.comment_text %>
+          <%= c.text %>
           <div class="post-menus">
             <% if c.user_id == @current_user.id %>
               <%= link_to "削除", post_comment_path(@post, c), method: :delete %>
@@ -67,7 +67,7 @@
     <%= form_with(model: [@post, @comment], local: true) do |f| %>
       <div class="form">
         <div class="form-body">
-          <%= f.text_area :comment_text %>
+          <%= f.text_area :text %>
           <%= f.submit 'コメントを投稿する' %>
         </div>
       </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -14,7 +14,7 @@
           </div>
         </div> 
         <div class="overflow-wrap">
-          <%= r.message_text %>
+          <%= r.text %>
           <div class="room-menus">
             <% if r.user_id == @current_user.id %>
               <%= link_to "削除", room_message_path(@room, r), method: :delete %>
@@ -30,7 +30,7 @@
     <%= form_with(model: [@room,  @message], local: true) do |f| %>
       <div class="form">
         <div class="form-body">
-          <%= f.text_field :message_text, :placeholder => "メッセージを入力して下さい" , :size => 70 %>
+          <%= f.text_field :text, :placeholder => "メッセージを入力して下さい" , :size => 70 %>
           <%= f.hidden_field :room_id, :value => @room.id %>
           <br>
           <%= f.submit "投稿する" %>

--- a/db/migrate/20220715025653_rename_comment_text_column_to_comments.rb
+++ b/db/migrate/20220715025653_rename_comment_text_column_to_comments.rb
@@ -1,4 +1,5 @@
 class RenameCommentTextColumnToComments < ActiveRecord::Migration[6.1]
   def change
+    rename_column :comments, :comment_text, :text
   end
 end

--- a/db/migrate/20220715025653_rename_comment_text_column_to_comments.rb
+++ b/db/migrate/20220715025653_rename_comment_text_column_to_comments.rb
@@ -1,0 +1,4 @@
+class RenameCommentTextColumnToComments < ActiveRecord::Migration[6.1]
+  def change
+  end
+end

--- a/db/migrate/20220715032337_rename_message_text_column_to_messages.rb
+++ b/db/migrate/20220715032337_rename_message_text_column_to_messages.rb
@@ -1,0 +1,5 @@
+class RenameMessageTextColumnToMessages < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :messages, :message_text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_21_070007) do
+ActiveRecord::Schema.define(version: 2022_07_15_025653) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2022_05_21_070007) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.text "comment_text"
+    t.text "text"
     t.integer "user_id", null: false
     t.integer "post_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_15_025653) do
+ActiveRecord::Schema.define(version: 2022_07_15_032337) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2022_07_15_025653) do
   end
 
   create_table "messages", force: :cascade do |t|
-    t.text "message_text"
+    t.text "text"
     t.integer "user_id"
     t.integer "room_id"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
 
   factory :comment do
     association :post
-    comment_text { 'Commentのテスト投稿' }
+    text { 'Commentのテスト投稿' }
   end
 end

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
 
   factory :message do
-    message_text { 'Messageのテスト投稿' }
+    text { 'Messageのテスト投稿' }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,26 +8,26 @@ RSpec.describe "Comments Model", type: :model do
   describe '#create' do
     context '投稿内容が1文字のとき' do
       it '投稿が成功すること' do
-        @comment.comment_text = 'a' * 1
+        @comment.text = 'a' * 1
         @comment.valid?
       end
     end
     context '投稿内容がないとき' do
       it '投稿が失敗すること' do
-        @comment.comment_text = ''
+        @comment.text = ''
         @comment.valid?
         # expect(@comment.errors.full_messages).to include('Contentを入力してください')
       end
     end
     context '投稿内容が1000文字のとき' do
       it '投稿が成功すること' do
-        @comment.comment_text = 'a' * 1000
+        @comment.text = 'a' * 1000
         @comment.valid?
       end
     end
     context '投稿内容が1001文字のとき' do
       it '投稿が失敗すること' do
-        @comment.comment_text = 'a' * 1001
+        @comment.text = 'a' * 1001
         @comment.valid?
         # expect(@comment.errors.full_messages).to include('Contentは1000文字以内で入力してください')
       end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -8,26 +8,26 @@ RSpec.describe "Messages Model", type: :model do
   describe '#create' do
     context '投稿内容が1文字のとき' do
       it '投稿が成功すること' do
-        @message.message_text = 'a' * 1
+        @message.text = 'a' * 1
         @message.valid?
       end
     end
     context '投稿内容がないとき' do
       it '投稿が失敗すること' do
-        @message.message_text = ''
+        @message.text = ''
         @message.valid?
         # expect(@message.errors.full_messages).to include('Contentを入力してください')
       end
     end
     context '投稿内容が1000文字のとき' do
       it '投稿が成功すること' do
-        @message.message_text = 'a' * 1000
+        @message.text = 'a' * 1000
         @message.valid?
       end
     end
     context '投稿内容が1001文字のとき' do
       it '投稿が失敗すること' do
-        @message.message_text = 'a' * 1001
+        @message.text = 'a' * 1001
         @message.valid?
         # expect(@message.errors.full_messages).to include('Contentは1000文字以内で入力してください')
       end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Comments Request", type: :request do
     context 'パラメータが正常なとき' do
       it 'コメントが投稿できること' do
         expect do
-          post post_comments_path(user_post.id), params: { comment: {comment_text: "コメントを投稿しました"} }
+          post post_comments_path(user_post.id), params: { comment: {text: "コメントを投稿しました"} }
         end.to change(Comment, :count).by(+1)
         expect(response).to have_http_status(:redirect)
       end
@@ -17,7 +17,7 @@ RSpec.describe "Comments Request", type: :request do
     context 'パラメータが不正なとき' do
       it 'コメントが投稿できないこと' do
         expect do
-          post post_comments_path(user_post.id), params: { comment: {comment_text: ""} }
+          post post_comments_path(user_post.id), params: { comment: {text: ""} }
         end.to change(Comment, :count).by(+0)
         expect(response).to have_http_status(:redirect)
       end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Messages Request", type: :request do
         it 'メッセージが投稿できること' do
           Room.create(user_ids: [user.id, other_user.id])
           expect do
-            post room_messages_path(Room.last.id), params: { message: {message_text: "メッセージを投稿しました"} }
+            post room_messages_path(Room.last.id), params: { message: {text: "メッセージを投稿しました"} }
           end.to change(Message, :count).by(1)
           expect(response).to have_http_status(:redirect)
         end
@@ -20,7 +20,7 @@ RSpec.describe "Messages Request", type: :request do
         it 'メッセージが投稿できないこと' do
           Room.create(user_ids: [user.id, other_user.id])
           expect do
-            post room_messages_path(Room.last.id), params: { message: {message_text: ""} }
+            post room_messages_path(Room.last.id), params: { message: {text: ""} }
           end.to change(Message, :count).by(0)
           expect(response).to have_http_status(:redirect)
         end
@@ -30,7 +30,7 @@ RSpec.describe "Messages Request", type: :request do
       it 'メッセージが投稿できないこと' do
         Room.create(user_ids: [user.id, other_user.id])
         expect do
-          post room_messages_path(Room.last.id), params: { message: {message_text: "メッセージを投稿しました"} }
+          post room_messages_path(Room.last.id), params: { message: {text: "メッセージを投稿しました"} }
         end.to change(Message, :count).by(0)
         expect(response).to have_http_status(:redirect)
       end
@@ -80,7 +80,7 @@ RSpec.describe "Messages Request", type: :request do
     context 'ログインしているとき' do
       include_context 'login_as_user'
       before do
-        post room_messages_path(Room.first.id), params: { message: {message_text: "メッセージを投稿しました"} }
+        post room_messages_path(Room.first.id), params: { message: {text: "メッセージを投稿しました"} }
       end
       context 'ユーザーが自分の場合' do
         it 'メッセージの削除ができること' do

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Posts Request", type: :request do
           expect do
             patch post_path(user_post.id), params: { post: {content: "投稿を編集しました"} }
           end.to change { Post.find(1).content }
-          expect(response).to redirect_to(posts_path)
+          expect(response).to redirect_to(post_path)
         end
       end
       context 'パラメータが不正な場合' do


### PR DESCRIPTION
- messagesテーブルのmessage_textカラムををtextへリネーム
- commentsテーブルのcomment_textカラムををtextへリネーム
各ファイルの設定も修正したので、developへマージします。